### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you encounter any bugs in the library, please [open an issue](https://github.
 
 ## Quick-start
 
-Below is a sample interactive console session designed to show some of the basic features and functionality of the ``lsm-db`` Python library. Also check out the [API documentation](http://lsm-db.readthedocs.org/en/latest/api.html).
+Below is a sample interactive console session designed to show some of the basic features and functionality of the ``lsm-db`` Python library. Also check out the [API documentation](https://lsm-db.readthedocs.io/en/latest/api.html).
 
 To begin, instantiate a `LSM` object, specifying a path to a database file.
 
@@ -83,7 +83,7 @@ By default when you attempt to look up a key, ``lsm-db`` will search for an exac
 
 ### Slices and Iteration
 
-The database can be iterated through directly, or sliced. When you are slicing the database the start and end keys need not exist -- ``lsm-db`` will find the closest key (details can be found in the [LSM.fetch_range()](http://lsm-db.readthedocs.org/en/latest/api.html#lsm.LSM.fetch_range) documentation).
+The database can be iterated through directly, or sliced. When you are slicing the database the start and end keys need not exist -- ``lsm-db`` will find the closest key (details can be found in the [LSM.fetch_range()](https://lsm-db.readthedocs.io/en/latest/api.html#lsm.LSM.fetch_range) documentation).
 
 ```python
 
@@ -224,4 +224,4 @@ bar
 
 For more information, check out the project's documentation, hosted at readthedocs:
 
-http://lsm-db.readthedocs.org/en/latest/
+https://lsm-db.readthedocs.io/en/latest/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
